### PR TITLE
Avoid extra function being created in onNextFrame's fallback

### DIFF
--- a/src/on-next-frame.ts
+++ b/src/on-next-frame.ts
@@ -11,7 +11,7 @@ const onNextFrame = hasRAF
     const currentTime = Date.now();
     const timeToCall = Math.max(0, 16.7 - (currentTime - prevTime));
     prevTime = currentTime + timeToCall;
-    setTimeout(() => callback(prevTime), timeToCall);
+    setTimeout(callback, timeToCall, prevTime);
   };
 
 export default onNextFrame;


### PR DESCRIPTION
`setTimeout` accepts arguments for `callback` function, so it's not necessary to create a one time function here